### PR TITLE
Run2025data

### DIFF
--- a/NSE_data_cleaning.Rmd
+++ b/NSE_data_cleaning.Rmd
@@ -24,10 +24,10 @@ library(haven)
 # 2. Inladen NSE benchmark bestand
 Voor het inlezen het oorsponkelijke SPSS (.sav) Benchmarkbestand gebruikt, en deze wordt hieronder direct ingelezen. 
 ```{r Inlezen .csv}
-NSEjaar <- 2024 #Kies het NSE jaar dat je wilt cleanen
+NSEjaar <- 2025 #Kies het NSE jaar dat je wilt cleanen
 user <- Sys.getenv("USERNAME") #Vind de Windows username voor het instellen van padnaam waar csv-bestand staat
 
-nse_benchmark <- read_sav(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/nse", NSEjaar,".csv",sep=""))
+nse_benchmark <- read.csv2(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/nse", NSEjaar,".csv",sep=""))
 
 head(nse_benchmark,10)
 ```

--- a/NSE_groepsgewijze_significantie-berekeningen.Rmd
+++ b/NSE_groepsgewijze_significantie-berekeningen.Rmd
@@ -33,7 +33,7 @@ library(dplyr)     #Nodig voor na_if() functie
 # 1. Inladen NSE benchmark bestand (clean data)
 
 ```{r Inlezen .csv}
-NSEjaar = 2024 # Kies het NSE jaar om te analyseren
+NSEjaar = 2025 # Kies het NSE jaar om te analyseren
 
 user <- Sys.getenv("USERNAME") #Vind de Windows username voor het instellen van padnaam waar csv-bestand staat
 load(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/NSE", NSEjaar, " nse_benchmark_clean.RData", sep = ""))

--- a/NSE_groepsgewijze_significantie-berekeningen_jaar.Rmd
+++ b/NSE_groepsgewijze_significantie-berekeningen_jaar.Rmd
@@ -30,7 +30,7 @@ library(dplyr)     #Nodig voor na_if() functie
 # 1. Inladen NSE benchmark bestanden (clean data)
 
 ```{r Inlezen .csv}
-NSEjaarT1 = 2023 #Kies NSE vergelijkingsjaar (oudste jaar)
+NSEjaarT1 = 2024 #Kies NSE vergelijkingsjaar (oudste jaar)
 # Oudste jaar eerst inlezen
 user <- Sys.getenv("USERNAME") #Vind de Windows username voor het instellen van padnaam waar csv-bestand staat
 load(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/NSE", NSEjaarT1, " nse_benchmark_clean.RData", sep = ""))
@@ -43,7 +43,7 @@ vec_vorm_T1            <- vec_vorm
 vec_groepHU_T1         <- vec_groepHU
 NSEcrohos_T1           <- NSEcrohos
 
-NSEjaar = 2024 # Kies het NSE jaar om te analyseren als nieuwste jaar
+NSEjaar = 2025 # Kies het NSE jaar om te analyseren als nieuwste jaar
 # Nieuwste jaar vervolgens inlezen
 load(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/NSE", NSEjaar, " nse_benchmark_clean.RData", sep = ""))
 ```

--- a/NSE_prioriteitenmatrix-berekeningen.Rmd
+++ b/NSE_prioriteitenmatrix-berekeningen.Rmd
@@ -35,7 +35,7 @@ library(corrplot)  #Nodig voor het visualiseren van correlaties via corplot()
 # 2. Inladen NSE benchmark bestand (clean data)
 
 ```{r Inlezen .csv, ca. 15 sec.}
-NSEjaar = 2024 # Kies het NSE jaar om te analyseren
+NSEjaar = 2025 # Kies het NSE jaar om te analyseren
 user <- Sys.getenv("USERNAME") #Vind de Windows username voor het instellen van padnaam waar csv-bestand staat
 load(paste("C:/Users/",user,"/Stichting Hogeschool Utrecht/FCA-DA-P - Analytics/NSE/data/NSE", NSEjaar, " nse_benchmark_clean.RData", sep = ""))
 

--- a/NSE_prioriteitenmatrix-berekeningen.Rmd
+++ b/NSE_prioriteitenmatrix-berekeningen.Rmd
@@ -229,7 +229,7 @@ for (ind_croho in 1:Ncrohos)
       N[ind_vorm,ind_ho,ind_croho] <-length(unique(HUdoorsnede$UniekNummer))
       
       # Als N < 10 of variantie = 0, dan geen rwa uitvoeren (=randvoorwaarden RWA)
-      if (N[ind_vorm,ind_ho,ind_croho] < 10 | var(HUdoorsnede$TEVREDENHEIDALGEMEEN_01) == 0) 
+      if (N[ind_vorm,ind_ho,ind_croho] < 10 | var(HUdoorsnede$TEVREDENHEIDALGEMEEN_01) == 0 | var(HUdoorsnede$TEVREDENHEIDALGEMEEN_02) == 0) 
       {
         next #Sla groep over en ga naar volgende iteratie
       }


### PR DESCRIPTION
- Jaar parameter in elk script aangepast naar 2025
- Mini-bug in prioriteitenmatrix script quick & dirty opgelost: voor 1 specifieke dwarsdoorsnede (ind_croho = 12, ind_ho = 3, ind_vorm = 2) en 1 vraag (TEVREDENHEIDALGEMEEN_02) was het zo dat alle studenten daar exact hetzelfde antwoord hebben gegeven, wat leidt tot een variantie = 0. De rwa functie kan voor die predictor dan geen rwa bijdrage uitrekenen en geeft een error. Doorgevoerde oplossing is om de rwa niet te draaien (d.w.z. geen prioriteitenmatrix berekening) als de variantie = 0 voor een dwarsdoorsnede en deze specifieke vraag. 